### PR TITLE
Release/1.2.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,3 @@
 [submodule "src/main/resources/assets/document-formats"]
 	path = src/main/resources/assets/document-formats
 	url = https://github.com/ONLYOFFICE/document-formats
-	branch = master

--- a/3rd-Party.license
+++ b/3rd-Party.license
@@ -13,6 +13,10 @@ com.fasterxml.jackson.core.jackson-databind - General data-binding functionality
 License:              Apache License 2.0
 License File:         com.fasterxml.jackson.core.jackson-databind.license
 
+com.fasterxml.jackson.dataformat.jackson-dataformat-properties - Support for reading and writing content of "Java Properties" style configuration files as if there was implied nesting structure (by default using dots as separators). (https://github.com/FasterXML/jackson-dataformats-text/blob/2.18/LICENSE)
+License:              Apache License 2.0
+License File:         com.fasterxml.jackson.dataformat.jackson-dataformat-properties.license
+
 org.json.json       - JSON is a light-weight, language independent, data interchange format. See http://www.JSON.org/ The files in this package implement JSON encoders/decoders in Java. It also includes the capability to convert between JSON and XML, HTTP headers, Cookies, and CDL. This is a reference implementation. (https://github.com/stleary/JSON-java/blob/master/LICENSE)
 License:              Public Domain
 License File:         org.json.json.license

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+##
+## Added
+- commands for working with forgotten files
+
 ## 1.1.2
 ## Changed
 - fixed load properties in ConfigurationUtils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - format repository (pdf documentType for docxf and oform, fb2 additional mime, pdf as documentType in editor)
 - the formsdataurl parameter to the Callback
 - the model FormData
+- documenteditor/callback/ForcesaveType#SUBMIT_FORM
 - editorconfig/customization/Features#roles
 - editorconfig/Customization#close
 - error status -9 and -10 to ConvertResponse.Error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+- sr-Cyrl-RS empty file templates
+
 ## 1.1.2
 ## Changed
 - fixed load properties in ConfigurationUtils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-##
+## 1.2.0
 ## Added
 - DocumentType - PDF
 - format repository (pdf documentType for docxf and oform, fb2 additional mime, pdf as documentType in editor)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 - sr-Cyrl-RS empty file templates
 
+##
+## Added
+- editorconfig/customization/Features#roles
+- editorconfig/Customization#close
+
+## Changed
+- the editorconfig/customization/Goback#requestClose field is deprecated
+
 ## 1.1.2
 ## Changed
 - fixed load properties in ConfigurationUtils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ##
 ## Added
+- DocumentType - PDF
 - format repository (pdf documentType for docxf and oform, fb2 additional mime, pdf as documentType in editor)
 - the formsdataurl parameter to the Callback
 - the model FormData

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ##
 ## Added
+- format repository (pdf documentType for docxf and oform, fb2 additional mime, pdf as documentType in editor)
 - the formsdataurl parameter to the Callback
 - the model FormData
 - editorconfig/customization/Features#roles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+##
+## Added
+- error status -9 for Convert Service
+
 ## 1.1.2
 ## Changed
 - fixed load properties in ConfigurationUtils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+##
+## Added
+- the formsdataurl parameter to the Callback
+- the model FormData
+
 ## 1.1.2
 ## Changed
 - fixed load properties in ConfigurationUtils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 1.1.2
 ## Changed
+- empty files, pdf instead docxf
 - fixed load properties in ConfigurationUtils
 - improving DefaultConfigService
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Change Log
 
-- sr-Cyrl-RS empty file templates
+## 
+## Changed
+- empty files, pdf instead docxf
 
 ## 1.1.2
 ## Changed
-- empty files, pdf instead docxf
 - fixed load properties in ConfigurationUtils
 - improving DefaultConfigService
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ##
 ## Added
-- error status -9 for Convert Service
+- error status -9 and -10 to ConvertResponse.Error
 - sr-Cyrl-RS empty file templates
 
 ## 1.1.2

--- a/demo-example/pom.xml
+++ b/demo-example/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>com.onlyoffice</groupId>
 			<artifactId>docs-integration-sdk</artifactId>
-			<version>0.0.1-SNAPSHOT</version>
+			<version>1.1.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/licenses/3rd-Party.license
+++ b/licenses/3rd-Party.license
@@ -13,6 +13,10 @@ com.fasterxml.jackson.core.jackson-databind - General data-binding functionality
 License:              Apache License 2.0
 License File:         com.fasterxml.jackson.core.jackson-databind.license
 
+com.fasterxml.jackson.dataformat.jackson-dataformat-properties - Support for reading and writing content of "Java Properties" style configuration files as if there was implied nesting structure (by default using dots as separators). (https://github.com/FasterXML/jackson-dataformats-text/blob/2.18/LICENSE)
+License:              Apache License 2.0
+License File:         com.fasterxml.jackson.dataformat.jackson-dataformat-properties.license
+
 org.json.json       - JSON is a light-weight, language independent, data interchange format. See http://www.JSON.org/ The files in this package implement JSON encoders/decoders in Java. It also includes the capability to convert between JSON and XML, HTTP headers, Cookies, and CDL. This is a reference implementation. (https://github.com/stleary/JSON-java/blob/master/LICENSE)
 License:              Public Domain
 License File:         org.json.json.license

--- a/licenses/com.fasterxml.jackson.dataformat.jackson-dataformat-properties.license
+++ b/licenses/com.fasterxml.jackson.dataformat.jackson-dataformat-properties.license
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.onlyoffice</groupId>
     <artifactId>docs-integration-sdk</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -72,17 +72,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.5</version>
+            <version>2.17.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-properties</artifactId>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.13.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-properties</artifactId>
-            <version>2.13.5</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.onlyoffice</groupId>
     <artifactId>docs-integration-sdk</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/onlyoffice/manager/document/DefaultDocumentManager.java
+++ b/src/main/java/com/onlyoffice/manager/document/DefaultDocumentManager.java
@@ -202,6 +202,8 @@ public abstract class DefaultDocumentManager implements DocumentManager {
                 return "xlsx";
             case SLIDE:
                 return "pptx";
+            case PDF:
+                return "pdf";
             default:
                 return null;
         }
@@ -219,9 +221,6 @@ public abstract class DefaultDocumentManager implements DocumentManager {
             if (format.getType() != null && format.getName().equals(extension)) {
                 switch (format.getType()) {
                     case WORD:
-                        if (format.getName().equals("docxf") && format.getConvert().contains("pdf")) {
-                            return "pdf";
-                        }
                         if (format.getConvert().contains("docx")) {
                             return "docx";
                         }
@@ -236,6 +235,10 @@ public abstract class DefaultDocumentManager implements DocumentManager {
                             return "pptx";
                         }
                         break;
+                    case PDF:
+                        if (format.getConvert().contains("pdf")) {
+                            return "pdf";
+                        }
                     default:
                         break;
                 }

--- a/src/main/java/com/onlyoffice/manager/document/DefaultDocumentManager.java
+++ b/src/main/java/com/onlyoffice/manager/document/DefaultDocumentManager.java
@@ -216,7 +216,7 @@ public abstract class DefaultDocumentManager implements DocumentManager {
         }
 
         for (Format format : this.formats) {
-            if (format.getName().equals(extension)) {
+            if (format.getType() != null && format.getName().equals(extension)) {
                 switch (format.getType()) {
                     case WORD:
                         if (format.getName().equals("docxf") && format.getConvert().contains("pdf")) {

--- a/src/main/java/com/onlyoffice/manager/document/DefaultDocumentManager.java
+++ b/src/main/java/com/onlyoffice/manager/document/DefaultDocumentManager.java
@@ -115,7 +115,7 @@ public abstract class DefaultDocumentManager implements DocumentManager {
     public DocumentType getDocumentType(final String fileName) {
         String fileExtension = getExtension(fileName);
 
-        for (Format format : this.formats) {
+        for (Format format : getFormats()) {
             if (format.getName().equals(fileExtension)) {
                 return format.getType();
             }
@@ -159,7 +159,7 @@ public abstract class DefaultDocumentManager implements DocumentManager {
             return false;
         }
 
-        for (Format format : this.formats) {
+        for (Format format : getFormats()) {
             if (format.getName().equals(fileExtension) && format.getActions().contains(action)) {
                 return true;
             }
@@ -215,7 +215,7 @@ public abstract class DefaultDocumentManager implements DocumentManager {
             return null;
         }
 
-        for (Format format : this.formats) {
+        for (Format format : getFormats()) {
             if (format.getName().equals(extension)) {
                 switch (format.getType()) {
                     case WORD:
@@ -253,7 +253,7 @@ public abstract class DefaultDocumentManager implements DocumentManager {
             return null;
         }
 
-        for (Format format : formats) {
+        for (Format format : getFormats()) {
             if (format.getName().equals(extension)) {
                 return format.getConvert();
             }
@@ -278,7 +278,7 @@ public abstract class DefaultDocumentManager implements DocumentManager {
             );
         }
 
-        for (Format format : formats) {
+        for (Format format : getFormats()) {
             if (format.getActions().contains("lossy-edit")) {
                 result.put(format.getName(), formatsLossyEditList.contains(format.getName()));
             }
@@ -297,10 +297,9 @@ public abstract class DefaultDocumentManager implements DocumentManager {
 
     @Override
     public List<String> getCompareFileExtensions() {
-        List<Format> supportedFormats = formats;
         List<String> result = new ArrayList<>();
 
-        for (Format format : supportedFormats) {
+        for (Format format : getFormats()) {
             if (DocumentType.WORD.equals(format.getType())) {
                 result.add(format.getName());
             }
@@ -311,10 +310,9 @@ public abstract class DefaultDocumentManager implements DocumentManager {
 
     @Override
     public List<String> getMailMergeExtensions() {
-        List<Format> supportedFormats = formats;
         List<String> result = new ArrayList<>();
 
-        for (Format format : supportedFormats) {
+        for (Format format : getFormats()) {
             if (DocumentType.CELL.equals(format.getType())) {
                 result.add(format.getName());
             }

--- a/src/main/java/com/onlyoffice/model/commandservice/CommandResponse.java
+++ b/src/main/java/com/onlyoffice/model/commandservice/CommandResponse.java
@@ -27,6 +27,7 @@ import lombok.Setter;
 import org.json.JSONObject;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 
@@ -50,6 +51,11 @@ public class CommandResponse {
      * Defines the document identifier used to unambiguously identify the document file.
      */
     private String key;
+
+    /**
+     * Defines the document identifiers used to unambiguously identify the document file.
+     */
+    private List<String> keys;
 
     /**
      * Defines the document license information: "end_date" - the license expiration date,
@@ -81,6 +87,11 @@ public class CommandResponse {
      * "expire" - date of viewing expiration for this user.
      */
     private JSONObject quota;
+
+    /**
+     * Defines the link to the edited document to be saved with the document storage service.
+     */
+    private String url;
 
     /**
      * Defines the document version.

--- a/src/main/java/com/onlyoffice/model/commandservice/commandrequest/Command.java
+++ b/src/main/java/com/onlyoffice/model/commandservice/commandrequest/Command.java
@@ -27,6 +27,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public enum Command {
 
     /**
+     * This command allows to delete a forgotten file.
+     */
+    @JsonProperty("deleteForgotten")
+    DELETE_FORGOTTEN,
+
+    /**
      * This command allows to disconnect the specified users from the document editing service.
      */
     @JsonProperty("drop")
@@ -37,6 +43,18 @@ public enum Command {
      */
     @JsonProperty("forcesave")
     FORCESAVE,
+
+    /**
+     * This command allows to request a forgotten file.
+     */
+    @JsonProperty("getForgotten")
+    GET_FORGOTTEN,
+
+    /**
+     * This command allows to request a list of the forgotten files.
+     */
+    @JsonProperty("getForgottenList")
+    GET_FORGOTTEN_LIST,
 
     /**
      * This command allows to request a document status and the list of the identifiers

--- a/src/main/java/com/onlyoffice/model/commandservice/commandrequest/Command.java
+++ b/src/main/java/com/onlyoffice/model/commandservice/commandrequest/Command.java
@@ -35,7 +35,7 @@ public enum Command {
     /**
      * This command allows to forcibly save the document being edited without closing it.
      */
-    @JsonProperty("fercesave")
+    @JsonProperty("forcesave")
     FORCESAVE,
 
     /**

--- a/src/main/java/com/onlyoffice/model/convertservice/ConvertRequest.java
+++ b/src/main/java/com/onlyoffice/model/convertservice/ConvertRequest.java
@@ -21,6 +21,7 @@ package com.onlyoffice.model.convertservice;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.onlyoffice.model.common.RequestEntity;
+import com.onlyoffice.model.convertservice.convertrequest.PDF;
 import com.onlyoffice.model.convertservice.convertrequest.Thumbnail;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -85,6 +86,11 @@ public class ConvertRequest implements RequestEntity {
      * content).
      */
     private String outputtype;
+
+    /**
+     * Defines settings for converting document files to pdf.
+     */
+    private PDF pdf;
 
     /**
      * Defines the password for the document file if it is protected with a password.

--- a/src/main/java/com/onlyoffice/model/convertservice/ConvertResponse.java
+++ b/src/main/java/com/onlyoffice/model/convertservice/ConvertResponse.java
@@ -118,7 +118,12 @@ public class ConvertResponse {
         /**
          * Error automatically determine the output file format (the error code is -9).
          */
-        OOXML_OUTPUT_TYPE(-9, "Error automatically determine the output file format");
+        OOXML_OUTPUT_TYPE(-9, "Error automatically determine the output file format"),
+
+        /**
+         * Size limit exceeded" (the error code is -10).
+         */
+        SIZE_LIMIT_EXCEEDED(-10, "Size limit exceeded");
 
         /**
          * Defines the error code.

--- a/src/main/java/com/onlyoffice/model/convertservice/ConvertResponse.java
+++ b/src/main/java/com/onlyoffice/model/convertservice/ConvertResponse.java
@@ -113,7 +113,12 @@ public class ConvertResponse {
         /**
          * Invalid token (the error code is -8).
          */
-        TOKEN(-8, "Invalid token");
+        TOKEN(-8, "Invalid token"),
+
+        /**
+         * Error automatically determine the output file format (the error code is -9).
+         */
+        OOXML_OUTPUT_TYPE(-9, "Error automatically determine the output file format");
 
         /**
          * Defines the error code.

--- a/src/main/java/com/onlyoffice/model/convertservice/convertrequest/PDF.java
+++ b/src/main/java/com/onlyoffice/model/convertservice/convertrequest/PDF.java
@@ -1,0 +1,40 @@
+/**
+ *
+ * (c) Copyright Ascensio System SIA 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.onlyoffice.model.convertservice.convertrequest;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
+public class PDF {
+
+    /**
+     * Defines whether the document will be converted to the pdf form (true) or to a regular pdf file (false).
+     */
+    private Boolean form;
+}

--- a/src/main/java/com/onlyoffice/model/documenteditor/Callback.java
+++ b/src/main/java/com/onlyoffice/model/documenteditor/Callback.java
@@ -76,6 +76,11 @@ public class Callback {
     private ForcesaveType forcesavetype;
 
     /**
+     * Defines the URL to the JSON file with the submitted form data.
+     */
+    private String formsdataurl;
+
+    /**
      * Defines the object with the document changes history.
      * The object is present when the {@link Status} value is equal to 2 or 3 only.
      * It contains the object "changes" and "serverVersion",

--- a/src/main/java/com/onlyoffice/model/documenteditor/FormData.java
+++ b/src/main/java/com/onlyoffice/model/documenteditor/FormData.java
@@ -1,0 +1,56 @@
+/**
+ *
+ * (c) Copyright Ascensio System SIA 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+package com.onlyoffice.model.documenteditor;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.onlyoffice.model.documenteditor.formdata.FormSpecificType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Defines the submitted form data.
+ */
+@Getter
+@Setter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
+public class FormData {
+
+    /**
+     * The form key. If the current form is a radio button, then this field contains the form group key.
+     */
+    private String key;
+
+    /**
+     * The form tag.
+     */
+    private String tag;
+
+    /**
+     *  The current form value.
+     */
+    private String value;
+
+    /**
+     *  The form type.
+     */
+    private FormSpecificType type;
+}

--- a/src/main/java/com/onlyoffice/model/documenteditor/callback/ForcesaveType.java
+++ b/src/main/java/com/onlyoffice/model/documenteditor/callback/ForcesaveType.java
@@ -48,7 +48,12 @@ public enum ForcesaveType {
     /**
      * The force saving request is performed by timer with the settings from the server config (the type ID is 2).
      */
-    TIMER(2);
+    TIMER(2),
+
+    /**
+     * The force saving request is performed by submit form(the type ID is 3).
+     */
+    SUBMIT_FORM(3);
 
     /**
      * Defines the ID of the force saving request type.

--- a/src/main/java/com/onlyoffice/model/documenteditor/config/document/DocumentType.java
+++ b/src/main/java/com/onlyoffice/model/documenteditor/config/document/DocumentType.java
@@ -45,5 +45,12 @@ public enum DocumentType {
      * @see <a target="_top" href="https://github.com/ONLYOFFICE/document-formats">Formats repository</a>.
      */
     @JsonProperty("slide")
-    SLIDE
+    SLIDE,
+
+    /**
+     * PDF.
+     * @see <a target="_top" href="https://github.com/ONLYOFFICE/document-formats">Formats repository</a>.
+     */
+    @JsonProperty("pdf")
+    PDF
 }

--- a/src/main/java/com/onlyoffice/model/documenteditor/config/editorconfig/Customization.java
+++ b/src/main/java/com/onlyoffice/model/documenteditor/config/editorconfig/Customization.java
@@ -21,6 +21,7 @@ package com.onlyoffice.model.documenteditor.config.editorconfig;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.onlyoffice.model.documenteditor.config.editorconfig.customization.Anonymous;
+import com.onlyoffice.model.documenteditor.config.editorconfig.customization.Close;
 import com.onlyoffice.model.documenteditor.config.editorconfig.customization.Customer;
 import com.onlyoffice.model.documenteditor.config.editorconfig.customization.Features;
 import com.onlyoffice.model.documenteditor.config.editorconfig.customization.Goback;
@@ -71,6 +72,11 @@ public class Customization {
      */
     @Deprecated
     private Boolean chat;
+
+    /**
+     * Defines settings for the cross button to close the editor.
+     */
+    private Close close;
 
     /**
      * Defines if the user can edit and delete only his comments. The default value is "false".

--- a/src/main/java/com/onlyoffice/model/documenteditor/config/editorconfig/customization/Close.java
+++ b/src/main/java/com/onlyoffice/model/documenteditor/config/editorconfig/customization/Close.java
@@ -1,0 +1,48 @@
+/**
+ *
+ * (c) Copyright Ascensio System SIA 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.onlyoffice.model.documenteditor.config.editorconfig.customization;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Close {
+
+    /**
+     * Defines if the cross button to close the editor is displayed or hidden. The default value is "true".
+     */
+    private Boolean visible;
+
+    /**
+     * defines the tooltip text for a button in the editor header or the menu item text in the mobile editors
+     * and in the File menu of the web editors.
+     */
+    private String text;
+}

--- a/src/main/java/com/onlyoffice/model/documenteditor/config/editorconfig/customization/Features.java
+++ b/src/main/java/com/onlyoffice/model/documenteditor/config/editorconfig/customization/Features.java
@@ -40,6 +40,14 @@ import lombok.Setter;
 public class Features {
 
     /**
+     * defines if the role settings will be disabled in the pdf forms or not. If the parameter is equal to "false",
+     * then the role manager is hidden and viewing the form on behalf of a specific role is disabled.
+     * In this case, the Manage Roles and View Form buttons on the Forms tab and a drop-down list for setting
+     * the field role in the right panel will not be displayed. The default value is "true".
+     */
+    private Boolean roles;
+
+    /**
      * Defines if the spell checker is automatically switched on or off when the editor is loaded.
      * It is set as the initial spell checker value and the spell checker setting will not be hidden.
      * The default value is "true".

--- a/src/main/java/com/onlyoffice/model/documenteditor/config/editorconfig/customization/Goback.java
+++ b/src/main/java/com/onlyoffice/model/documenteditor/config/editorconfig/customization/Goback.java
@@ -49,10 +49,12 @@ public class Goback {
     /**
      * Defines that if the "Open file location" button is clicked, "events.onRequestClose" event is called
      * instead of opening a browser tab or window. The default value is "false".
+     * Deprecated since version 8.1. Please use the {@link com.onlyoffice.model.documenteditor.config.editorconfig.Customization#close close} parameter instead
      *
      * @see <a target="_top" href="https://api.onlyoffice.com/editors/config/events#onRequestClose">"onRequestClose"
      * event in API ONLYOFFICE</a>
      */
+    @Deprecated
     private Boolean requestClose;
 
     /**

--- a/src/main/java/com/onlyoffice/model/documenteditor/config/editorconfig/customization/Goback.java
+++ b/src/main/java/com/onlyoffice/model/documenteditor/config/editorconfig/customization/Goback.java
@@ -49,7 +49,8 @@ public class Goback {
     /**
      * Defines that if the "Open file location" button is clicked, "events.onRequestClose" event is called
      * instead of opening a browser tab or window. The default value is "false".
-     * Deprecated since version 8.1. Please use the {@link com.onlyoffice.model.documenteditor.config.editorconfig.Customization#close close} parameter instead
+     * Deprecated since version 8.1. Please use
+     * the {@link com.onlyoffice.model.documenteditor.config.editorconfig.Customization#close close} parameter instead
      *
      * @see <a target="_top" href="https://api.onlyoffice.com/editors/config/events#onRequestClose">"onRequestClose"
      * event in API ONLYOFFICE</a>

--- a/src/main/java/com/onlyoffice/model/documenteditor/formdata/FormSpecificType.java
+++ b/src/main/java/com/onlyoffice/model/documenteditor/formdata/FormSpecificType.java
@@ -1,0 +1,35 @@
+/**
+ *
+ * (c) Copyright Ascensio System SIA 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+package com.onlyoffice.model.documenteditor.formdata;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum FormSpecificType {
+    TEXT,
+    CHECK_BOX,
+    PICTURE,
+    COMBO_BOX,
+    DROP_DOWN_LIST,
+    DATE_TIME,
+    RADIO;
+}

--- a/src/test/java/com/onlyoffice/service/command/CommandServiceTest.java
+++ b/src/test/java/com/onlyoffice/service/command/CommandServiceTest.java
@@ -1,0 +1,115 @@
+/**
+ *
+ * (c) Copyright Ascensio System SIA 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.onlyoffice.service.command;
+
+import com.onlyoffice.manager.request.DefaultRequestManager;
+import com.onlyoffice.manager.request.RequestManager;
+import com.onlyoffice.manager.security.DefaultJwtManager;
+import com.onlyoffice.manager.security.JwtManager;
+import com.onlyoffice.manager.settings.DefaultSettingsManager;
+import com.onlyoffice.manager.settings.SettingsManager;
+import com.onlyoffice.manager.url.DefaultUrlManager;
+import com.onlyoffice.manager.url.UrlManager;
+import com.onlyoffice.model.commandservice.CommandRequest;
+import com.onlyoffice.model.commandservice.CommandResponse;
+import com.onlyoffice.model.commandservice.commandrequest.Command;
+import com.onlyoffice.model.common.RequestedService;
+import com.onlyoffice.model.settings.SettingsConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ExtendWith(MockitoExtension.class)
+@Disabled
+public class CommandServiceTest {
+
+    private UrlManager urlManager;
+    private JwtManager jwtManager;
+    private SettingsManager settingsManager;
+    private RequestManager requestManager;
+    private CommandService commandService;
+    private RequestedService requestedService;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        Map<String, String> settings = new HashMap<>();
+        settings.put(SettingsConstants.URL, "");
+        settings.put(SettingsConstants.SECURITY_KEY, "");
+
+        settingsManager = new DefaultSettingsManager() {
+            @Override
+            public String getSetting(final String name) {
+                return settings.get(name);
+            }
+
+            @Override
+            public void setSetting(final String name, final String value) {
+
+            }
+        };
+
+        urlManager = new DefaultUrlManager(settingsManager);
+        jwtManager = new DefaultJwtManager(settingsManager);
+        requestManager = new DefaultRequestManager(urlManager, jwtManager, settingsManager);
+
+         DefaultCommandService defaultCommandService = new DefaultCommandService(requestManager);
+        commandService = defaultCommandService;
+        requestedService = defaultCommandService;
+    }
+
+    @Test
+    void getForgottenList() throws Exception {
+        CommandRequest commandRequest = CommandRequest.builder()
+                .c(Command.GET_FORGOTTEN_LIST)
+                .build();
+
+        CommandResponse commandResponse = commandService.processCommand(commandRequest, null);
+        System.out.println(commandResponse.getKeys());
+    }
+
+    @Test
+    void getForgottenByKey() throws Exception {
+        CommandRequest commandRequest = CommandRequest.builder()
+                .c(Command.GET_FORGOTTEN)
+                .key("L_5gf4MJJSsm0d_DHFPipLU-sZvBciWu9R185wXv39U")
+                .build();
+
+        CommandResponse commandResponse = commandService.processCommand(commandRequest, null);
+        System.out.println(commandResponse.getKey() + " : " + commandResponse.getUrl());
+    }
+
+    @Test
+    void deleteForgotten() throws Exception {
+        CommandRequest commandRequest = CommandRequest.builder()
+                .c(Command.DELETE_FORGOTTEN)
+                .key("L_5gf4MJJSsm0d_DHFPipLU-sZvBciWu9R185wXv39U")
+                .build();
+
+        CommandResponse commandResponse = commandService.processCommand(commandRequest, null);
+        System.out.println(commandResponse.getKey());
+    }
+}


### PR DESCRIPTION
## Added
- DocumentType - PDF
- format repository (pdf documentType for docxf and oform, fb2 additional mime, pdf as documentType in editor)
- the formsdataurl parameter to the Callback
- the model FormData
- documenteditor/callback/ForcesaveType#SUBMIT_FORM
- editorconfig/customization/Features#roles
- editorconfig/Customization#close
- error status -9 and -10 to ConvertResponse.Error
- commands for working with forgotten files
- sr-Cyrl-RS empty file templates

## Changed
- the editorconfig/customization/Goback#requestClose field is deprecated
- pdf instead docxf